### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ By using this class, auto updates will be disabled when the plugin's new version
 1. Install the class as a dependency via composer:
 
 ```
-composer install blakewilson/wp-enforce-semver
+composer require blakewilson/wp-enforce-semver
 ```
 
 2. Initialize the class in your plugin:


### PR DESCRIPTION
When installing this library, I received the following error when running `composer install`:

> composer install blakewilson/wp-enforce-semver
Invalid argument blakewilson/wp-enforce-semver. Use "composer require blakewilson/wp-enforce-semver" instead to add packages to your composer.json.

```
composer --version
Composer version 2.6.6 2023-12-08 18:32:26
```

This updates the instruction to `composer require`.