### PR TITLE
Set priority to 20 for plugins_list_show_breaking_changes_message callback

### DIFF
--- a/src/EnforceSemVer.php
+++ b/src/EnforceSemVer.php
@@ -35,7 +35,7 @@ class EnforceSemVer {
 		$this->plugin_filename = $plugin_filename;
 
 		add_filter( 'auto_update_plugin', array( $this, 'disable_auto_updates_for_major_versions' ), 10, 2 );
-		add_action( 'plugins_loaded', array( $this, 'plugins_list_show_breaking_changes_message' ) );
+		add_action( 'plugins_loaded', array( $this, 'plugins_list_show_breaking_changes_message' ), 20 );
 	}
 
 	/**


### PR DESCRIPTION
This adjusts the priority of the `plugins_list_show_breaking_changes_message` callback attached to `plugins_loaded`. Without this change, the callback doesn't run in the plugin I'm adding this to.