### PR TITLE
Use `admin_init` action instead of `plugins_loaded` to only run on the admin side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # wp-enforce-semver
 
+## Unreleased
+
+- BREAKING: `plugins_list_show_breaking_changes_message` is now fired on the `admin_init` action instead of the `plugins_loaded` action to avoid running outside of the admin interface
+
 ## 2.0.2
 
 - Set priority to `20` in the `plugins_list_show_breaking_changes_message` callback (#4). Thanks @mindctrl!

--- a/src/EnforceSemVer.php
+++ b/src/EnforceSemVer.php
@@ -35,7 +35,7 @@ class EnforceSemVer {
 		$this->plugin_filename = $plugin_filename;
 
 		add_filter( 'auto_update_plugin', array( $this, 'disable_auto_updates_for_major_versions' ), 10, 2 );
-		add_action( 'plugins_loaded', array( $this, 'plugins_list_show_breaking_changes_message' ), 20 );
+		add_action( 'admin_init', array( $this, 'plugins_list_show_breaking_changes_message' ), 20 );
 	}
 
 	/**


### PR DESCRIPTION
When using the `plugins_loaded` action, it's possible to get the following error:

```
Fatal error: Uncaught Error: Call to undefined function get_plugins()
```

Since `get_plugins()` is an admin only function, but `plugins_loaded` runs on both the frontend and admin side. Changing `plugins_loaded` to `admin_init` will ensure the the `plugins_list_show_breaking_changes_message` function is only called on the admin side.