### PR TITLE
Call update message action more reliably

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,0 +1,24 @@
+name: PHPCS
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  phpcs:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.1'
+    - name: Install composer dependencies
+      run: composer install
+
+    - name: Install composer dependencies
+      run: composer install
+
+    - name: Run phpcs
+      run: composer phpcs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # wp-enforce-semver
 
-## 3.0.0 
+## Unreleased
+
+- Calls the `in_plugin_update_message-{$file}` action more reliably
+
+## 3.0.0
 
 - BREAKING: `plugins_list_show_breaking_changes_message` is now fired on the `admin_init` action instead of the `plugins_loaded` action to avoid running outside of the admin interface
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   testDir: './tests',
   testIgnore: "**/_setup/**",
   /* Run tests in files in parallel */
-  fullyParallel: true,
+  fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
@@ -37,10 +37,10 @@ export default defineConfig({
     { name: 'setup', testMatch: /.*\.setup\.ts/ },
     {
       name: 'chromium',
-      use: { 
+      use: {
         ...devices['Desktop Chrome'],
         // Use prepared auth state.
-        storageState: 'playwright/.auth/user.json', 
+        storageState: 'playwright/.auth/user.json',
       },
       dependencies: ['setup']
     },
@@ -50,7 +50,7 @@ export default defineConfig({
     //   use: {
     //     ...devices['Desktop Firefox'],
     //     // Use prepared auth state.
-    //     storageState: 'playwright/.auth/user.json', 
+    //     storageState: 'playwright/.auth/user.json',
     //   },
     //   dependencies: ['setup']
     // },
@@ -60,7 +60,7 @@ export default defineConfig({
     //   use: {
     //     ...devices['Desktop Safari'],
     //     // Use prepared auth state.
-    //     storageState: 'playwright/.auth/user.json', 
+    //     storageState: 'playwright/.auth/user.json',
     //   },
     //   dependencies: ['setup']
     // },

--- a/src/EnforceSemVer.php
+++ b/src/EnforceSemVer.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase
 /**
  * Class to setup the enforcement of semantic versioning in a WordPress plugin.
  *
@@ -34,8 +34,8 @@ class EnforceSemVer {
 	public function __construct( string $plugin_filename ) {
 		$this->plugin_filename = $plugin_filename;
 
-		$plugin_update_message_action_name = 'in_plugin_update_message-';
-    $plugin_update_message_action_name .= $this->plugin_filename;
+		$plugin_update_message_action_name  = 'in_plugin_update_message-';
+		$plugin_update_message_action_name .= $this->plugin_filename;
 
 		add_filter( 'auto_update_plugin', array( $this, 'disable_auto_updates_for_major_versions' ), 10, 2 );
 		add_action( $plugin_update_message_action_name, array( $this, 'plugins_list_show_breaking_changes_message' ), 20, 2 );
@@ -68,24 +68,24 @@ class EnforceSemVer {
 		} else {
 			return $update;
 		}
-  }
+	}
 
 	/**
-   * Show the breaking changes notice on the plugin's update.
-   * 
-   * @see https://developer.wordpress.org/reference/hooks/in_plugin_update_message-file/
-   * @param array $plugin_data An array of plugin metadata.
-   * @param object $response An object of metadata about the available plugin update
+	 * Show the breaking changes notice on the plugin's update.
+	 *
+	 * @see https://developer.wordpress.org/reference/hooks/in_plugin_update_message-file/
+	 * @param array  $plugin_data An array of plugin metadata.
+	 * @param object $response An object of metadata about the available plugin update.
 	 */
-  public function plugins_list_show_breaking_changes_message( $plugin_data, $response ) {
-    // Only print the message if there is a major change
+	public function plugins_list_show_breaking_changes_message( $plugin_data, $response ) {
+		// Only print the message if there is a major change.
 		if ( ! $this->does_new_version_have_major_change( $response->new_version, $plugin_data['Version'] ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			return;
 		}
 
 		$notice_text = __( '<br><br><b>THIS UPDATE MAY CONTAIN BREAKING CHANGES:</b> This plugin uses Semantic Versioning, and this new version is a major release. Please review the changelog before updating. <a href="https://semver.org" target="_blank">Learn more</a>', 'semantic-versioning' );
 		$notice_text = apply_filters( 'semantic_versioning_notice_text', $notice_text, $this->plugin_filename );
-  
+
 		printf( wp_kses_post( $notice_text ) );
 	}
 

--- a/src/EnforceSemVer.php
+++ b/src/EnforceSemVer.php
@@ -34,8 +34,11 @@ class EnforceSemVer {
 	public function __construct( string $plugin_filename ) {
 		$this->plugin_filename = $plugin_filename;
 
+		$plugin_update_message_action_name = 'in_plugin_update_message-';
+    $plugin_update_message_action_name .= $this->plugin_filename;
+
 		add_filter( 'auto_update_plugin', array( $this, 'disable_auto_updates_for_major_versions' ), 10, 2 );
-		add_action( 'admin_init', array( $this, 'plugins_list_show_breaking_changes_message' ), 20 );
+		add_action( $plugin_update_message_action_name, array( $this, 'plugins_list_show_breaking_changes_message' ), 20, 2 );
 	}
 
 	/**
@@ -65,55 +68,25 @@ class EnforceSemVer {
 		} else {
 			return $update;
 		}
-	}
+  }
 
 	/**
-	 * Check if the plugin has a major version update.
-	 *
-	 * @see https://developer.wordpress.org/reference/functions/get_plugin_updates/
+   * Show the breaking changes notice on the plugin's update.
+   * 
+   * @see https://developer.wordpress.org/reference/hooks/in_plugin_update_message-file/
+   * @param array $plugin_data An array of plugin metadata.
+   * @param object $response An object of metadata about the available plugin update
 	 */
-	private function has_major_update() {
-		if ( ! function_exists( 'get_plugin_updates' ) ) {
-			include_once ABSPATH . 'wp-admin/includes/update.php';
+  public function plugins_list_show_breaking_changes_message( $plugin_data, $response ) {
+    // Only print the message if there is a major change
+		if ( ! $this->does_new_version_have_major_change( $response->new_version, $plugin_data['Version'] ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			return;
 		}
-
-		$updates = get_plugin_updates();
-
-		if ( ! isset( $updates[ $this->plugin_filename ] ) ) {
-			return false;
-		}
-
-		$plugin_update = $updates[ $this->plugin_filename ];
-
-		if ( ! $this->does_new_version_have_major_change( $plugin_update->update->new_version, $plugin_update->Version ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
-	 * Show the breaking changes notice on the plugin's update.
-	 */
-	public function plugins_list_show_breaking_changes_message() {
-		$has_major_update = $this->has_major_update();
-
-		$action_name  = 'in_plugin_update_message-';
-		$action_name .= $this->plugin_filename;
 
 		$notice_text = __( '<br><br><b>THIS UPDATE MAY CONTAIN BREAKING CHANGES:</b> This plugin uses Semantic Versioning, and this new version is a major release. Please review the changelog before updating. <a href="https://semver.org" target="_blank">Learn more</a>', 'semantic-versioning' );
 		$notice_text = apply_filters( 'semantic_versioning_notice_text', $notice_text, $this->plugin_filename );
-
-		if ( $has_major_update ) {
-			add_action(
-				$action_name,
-				function( $data, $response ) use ( $notice_text ) {
-					printf( wp_kses_post( $notice_text ) );
-				},
-				10,
-				2
-			);
-		}
+  
+		printf( wp_kses_post( $notice_text ) );
 	}
 
 	/**

--- a/tests/_setup/my-test-plugin/my-test-plugin.php
+++ b/tests/_setup/my-test-plugin/my-test-plugin.php
@@ -29,7 +29,9 @@ function mock_plugin_update($transient) {
         'package'     => 'https://example.com/my-custom-plugin-v2.0.0.zip', // URL to the new version zip file
     ];
     
-    $transient->response[$plugin_file] = $update_data;
+    if($new_version !== '1.0.0') {
+      $transient->response[$plugin_file] = $update_data;
+    }
 
     return $transient;
 }

--- a/tests/_setup/my-test-plugin/my-test-plugin.php
+++ b/tests/_setup/my-test-plugin/my-test-plugin.php
@@ -20,8 +20,7 @@ function mock_plugin_update($transient) {
     }
 
     $plugin_file = 'my-test-plugin/my-test-plugin.php';
-
-    $new_version = '2.0.0';
+    $new_version = get_transient('my_test_plugin_version') ?: '2.0.0';
 
     $update_data = (object) [
         'slug'        => 'my-test-plugin',
@@ -29,7 +28,7 @@ function mock_plugin_update($transient) {
         'url'         => 'https://example.com/my-custom-plugin-changelog', // URL to the plugin changelog
         'package'     => 'https://example.com/my-custom-plugin-v2.0.0.zip', // URL to the new version zip file
     ];
-
+    
     $transient->response[$plugin_file] = $update_data;
 
     return $transient;

--- a/tests/_setup/my-test-plugin/my-test-plugin.php
+++ b/tests/_setup/my-test-plugin/my-test-plugin.php
@@ -20,16 +20,17 @@ function mock_plugin_update($transient) {
     }
 
     $plugin_file = 'my-test-plugin/my-test-plugin.php';
-    $new_version = get_transient('my_test_plugin_version') ?: '2.0.0';
+    $new_version = get_transient('my_test_plugin_version') ?: '1.0.0';
 
-    $update_data = (object) [
+    
+    if($new_version !== '1.0.0') {
+      $update_data = (object) [
         'slug'        => 'my-test-plugin',
         'new_version' => $new_version,
         'url'         => 'https://example.com/my-custom-plugin-changelog', // URL to the plugin changelog
         'package'     => 'https://example.com/my-custom-plugin-v2.0.0.zip', // URL to the new version zip file
-    ];
-    
-    if($new_version !== '1.0.0') {
+      ];
+
       $transient->response[$plugin_file] = $update_data;
     }
 

--- a/tests/wp-enforce-semver.spec.ts
+++ b/tests/wp-enforce-semver.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test';
 import { exec } from 'child_process';
-import exp from 'constants';
 
 let DEFAULT_BREAKING_CHANGE_TEXT = 'THIS UPDATE MAY CONTAIN BREAKING CHANGES: This plugin uses Semantic Versioning, and this new version is a major release. Please review the changelog before updating. Learn more' 
 

--- a/tests/wp-enforce-semver.spec.ts
+++ b/tests/wp-enforce-semver.spec.ts
@@ -73,3 +73,19 @@ test('plugin does not alter plugin list row with non breaking change', async ({ 
   // Cleanup  
   exec('npm run wp-env -- run cli wp transient set my_test_plugin_version "2.0.0"')
 })
+
+test('plugin does not alter plugin list row with no update', async ({ page }) => {
+  // My test plugin version is 1.0.0 so no update should be detected.
+  exec('npm run wp-env -- run cli wp transient set my_test_plugin_version "1.0.0"')
+
+  await page.goto('http://localhost:8888/wp-admin/plugins.php');
+
+  let pluginRow = page.locator('tr.active[data-plugin="my-test-plugin/my-test-plugin.php"]')
+
+  await expect(pluginRow).toContainText('Enable auto-updates')
+  await expect(pluginRow).toContainText('Version 1.0.0')
+  await expect(pluginRow).toContainText('My Test Plugin')
+
+  // Cleanup
+  exec('npm run wp-env -- run cli wp transient set my_test_plugin_version "2.0.0"')
+})


### PR DESCRIPTION
This PR calls the update message action (`in_plugin_update_message-{$file}`) more reliably.

Previously an action ran on `admin_init` which then in turn called the `in_plugin_update_message-{$file}` action. Now, the script just calls `in_plugin_update_message-{$file}` directly and the function that ran on `admin_init` has been removed.

More E2E tests were also added, as well as a phpcs action workflow.