### PR TITLE
Use symlink for e2e test plugin instead of file mirroring

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,30 +10,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*
+
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
         php-version: '8.1'
+
     - name: Install dependencies
       run: npm ci
+
     - name: Install composer dependencies
       run: composer install
-
-    # We use mirror repo paths here because it copies the files instead of symlink.
-    # Symlinks were proving difficult with wp-env/docker.
-    # TODO: Properly setup symlinks in docker container with local package in composer.
-    - name: Install composer dependencies (test plugin)
-      run: COMPOSER_MIRROR_PATH_REPOS=1 composer install
-      working-directory: ./tests/_setup/my-test-plugin
 
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
 
     - name: Setup Tests
       run: npm run test:start
+
+    - name: Install composer dependencies (test plugin)
+      run: npm run test:plugin:composer-install
+
+    - name: Activate test plugin
+      run: npm run test:plugin:activate
 
     - name: Run Playwright tests
       run: npm run test

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,8 +1,7 @@
 {
-  "plugins": [
-    "./tests/_setup/my-test-plugin"
-  ],
   "mappings": {
+    "app": ".",
+    "wp-content/plugins/my-test-plugin": "./tests/_setup/my-test-plugin",
     "wp-content/plugins/alter-breaking-change-text": "./tests/_setup/alter-breaking-change-text"
   }
 }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,36 @@
+# Development
+
+## Local Development
+
+### Setup
+1. `npm run test:start` - Start the local development server (requires docker)
+2. `npm run test:plugin:composer-install` - Composer install in the e2e test plugin. This symlinks the wp-enforce-semver dep in the e2e test plugin
+3. `npm run test:plugin:activate` - This activates the e2e test plugin
+
+### Interacting with the local environment
+
+This will set up a local WordPress instance with a plugin `my-test-plugin` installed and activated that mocks an update response. You can change the version of the mocked update response with the following command:
+
+```
+npm run test:plugin:set-version 2.0.0
+npm run test:plugin:set-version 1.1.0
+npm run test:plugin:set-version 5.1.2
+```
+
+This allows you to determine all of the different states from patch/minor/major changes and what those different states look like.
+
+## Running E2E tests
+
+Running E2E tests will happen when you open a PR to the repo, but if you'd like to run them locally, you can use the following command:
+
+```
+npm run test
+```
+
+Or, if you'd like a UI view for the tests cases running in Playwright, you can run:
+
+```
+npm run test:ui
+```
+
+In order to run the tests, you must make sure that you have followed the setup steps above.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "test:start": "npm run wp-env -- start",
     "test:clean": "npm run wp-env -- clean",
     "test:destroy": "npm run wp-env -- destroy",
+    "test:plugin:composer-install": "wp-env run cli --env-cwd=wp-content/plugins/my-test-plugin composer install",
+    "test:plugin:activate": "wp-env run cli wp plugin activate my-test-plugin",
+    "test:plugin:set-version": "wp-env run cli wp transient set my_test_plugin_version",
     "test": "playwright test",
     "test:ui": "playwright test --ui"
   },

--- a/tests/_setup/my-test-plugin/composer.json
+++ b/tests/_setup/my-test-plugin/composer.json
@@ -11,7 +11,7 @@
     "repositories": [
       {
         "type": "path",
-        "url": "../../../"
+        "url": "/var/www/html/app"
       }
     ]
 }

--- a/tests/_setup/my-test-plugin/composer.lock
+++ b/tests/_setup/my-test-plugin/composer.lock
@@ -4,15 +4,15 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "199c7efe6c408db1b0e05db18c1ff4ad",
+    "content-hash": "fd31468231d7827ccdec754420ef2bbd",
     "packages": [
         {
             "name": "blakewilson/wp-enforce-semver",
-            "version": "dev-add-e2e-tests",
+            "version": "dev-main",
             "dist": {
                 "type": "path",
-                "url": "../../..",
-                "reference": "3cfd4b82a236d947a52dbddf2ab3c598f0a483d8"
+                "url": "/var/www/html/app",
+                "reference": "91833c93c4046c2c3fcd2743b0934a6824056e70"
             },
             "require": {
                 "phlak/semver": "^4.1"
@@ -47,7 +47,7 @@
             ],
             "description": "A class to enforce SemVer in your WordPress plugins.",
             "transport-options": {
-                "relative": true
+                "relative": false
             }
         },
         {
@@ -120,5 +120,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/tests/wp-enforce-semver.spec.ts
+++ b/tests/wp-enforce-semver.spec.ts
@@ -25,7 +25,7 @@ test('BREAKING CHANGE: message is properly displayed in plugins list', async ({ 
   const page = await context.newPage();
 
   // Set the version to a "breaking" version
-  execSync('npm run wp-env -- run cli wp transient set my_test_plugin_version "2.0.0"')
+  execSync('npm run test:plugin:set-version 2.0.0')
 
   await page.goto('http://localhost:8888/wp-admin/plugins.php');
 
@@ -36,7 +36,7 @@ test('BREAKING CHANGE: message is properly displayed in plugins list', async ({ 
 
 test('BREAKING CHANGE: auto updates are properly disabled in plugins list', async ({ page }) => {
   // Set the version to a "breaking" version
-  execSync('npm run wp-env -- run cli wp transient set my_test_plugin_version "2.0.0"')
+  execSync('npm run test:plugin:set-version 2.0.0')
 
   await page.goto('http://localhost:8888/wp-admin/plugins.php');
 
@@ -48,7 +48,7 @@ test('BREAKING CHANGE: auto updates are properly disabled in plugins list', asyn
 
 test('BREAKING CHANGE: plugin shows breaking change custom message', async ({ page }) => {
   // Set the version to a "breaking" version
-  execSync('npm run wp-env -- run cli wp transient set my_test_plugin_version "2.0.0"')
+  execSync('npm run test:plugin:set-version 2.0.0')
 
   await page.goto('http://localhost:8888/wp-admin/plugins.php');
 
@@ -69,7 +69,7 @@ test('BREAKING CHANGE: plugin shows breaking change custom message', async ({ pa
 
 test('plugin does not alter plugin list row with non breaking change', async ({ page }) => {
   // My test plugin default version is 1.0.0 so 1.1.0 is non-breaking
-  execSync('npm run wp-env -- run cli wp transient set my_test_plugin_version "1.1.0"')
+  execSync('npm run test:plugin:set-version 1.1.0')
 
   await page.goto('http://localhost:8888/wp-admin/plugins.php');
 


### PR DESCRIPTION
Instead of mirroring files for the e2e test plugin, use a symlink for a better development experience.